### PR TITLE
Fix memory spike simulation to prevent memory exhaustion

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,30 @@
+def simulate_memory_spike():
+    global memory_spike_active, allocated_memory
+    memory_spike_active = True
+    MEMORY_SPIKE_COUNTER.inc()
+    
+    print(f"[Memory Spike] Starting memory spike simulation")
+    
+    # Simulate memory spike by allocating memory
+    try:
+        # Allocate ~700MB of memory in smaller chunks
+        total_allocated = 0
+        chunk_size = 1 * 1024 * 1024  # 1MB chunks
+        for i in range(700):
+            allocated_memory.append(bytearray(chunk_size))
+            total_allocated += chunk_size
+            if i % 50 == 0:  # Print progress every 50MB
+                print(f"[Memory Spike] Allocated {total_allocated / (1024 * 1024):.1f} MB")
+    except MemoryError as e:
+        print(f"[Memory Spike] Memory allocation error: {e}")
+    
+    print(f"[Memory Spike] Memory allocation complete, holding for 60 seconds")
+    
+    # Keep the memory allocated for 60 seconds
+    time.sleep(60)
+    
+    # Release memory
+    print(f"[Memory Spike] Releasing allocated memory")
+    allocated_memory.clear()
+    memory_spike_active = False
+    print(f"[Memory Spike] Memory spike simulation completed")


### PR DESCRIPTION
This pull request addresses the issue of memory exhaustion during the memory spike simulation in the test application. The `simulate_memory_spike` function was allocating a large amount of memory (around 700MB) in a single loop iteration, which could potentially cause the application to run out of memory and crash.

The proposed fix involves modifying the `simulate_memory_spike` function to allocate memory in smaller chunks (1MB) instead of allocating the entire 700MB at once. This reduces the risk of memory exhaustion and allows the simulation to run more smoothly.

Additionally, the fix uses the `clear` method to release the allocated memory more efficiently after the simulation is complete.

With this fix, the memory spike simulation should run without causing memory exhaustion or application crashes.