### PR TITLE
Fix memory spike simulation to prevent out-of-memory errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+
+def simulate_memory_spike():
+    global memory_spike_active, allocated_memory
+    memory_spike_active = True
+    MEMORY_SPIKE_COUNTER.inc()
+    
+    print(f"[Memory Spike] Starting memory spike simulation")
+    
+    # Simulate memory spike by allocating memory
+    try:
+        # Allocate ~700MB of memory in smaller chunks
+        total_allocated = 0
+        chunk_size = 1 * 1024 * 1024  # 1MB chunks
+        for i in range(700):
+            allocated_memory.append(bytearray(chunk_size))
+            total_allocated += chunk_size
+            if i % 50 == 0:  # Print progress every 50MB
+                print(f"[Memory Spike] Allocated {total_allocated / (1024 * 1024):.1f} MB")
+    except MemoryError as e:
+        print(f"[Memory Spike] Memory allocation error: {e}")
+    
+    print(f"[Memory Spike] Memory allocation complete, holding for 60 seconds")
+    
+    # Keep the memory allocated for 60 seconds
+    time.sleep(60)
+    
+    # Release memory
+    print(f"[Memory Spike] Releasing allocated memory")
+    del allocated_memory[:]
+    memory_spike_active = False
+    print(f"[Memory Spike] Memory spike simulation completed")


### PR DESCRIPTION
The current implementation of the `simulate_memory_spike` function allocates memory in large chunks (10MB), which can lead to out-of-memory errors and high memory pressure on the pod. This pull request modifies the function to allocate memory in smaller chunks (1MB) to mitigate this issue.

Changes:

1. Modified the `simulate_memory_spike` function to allocate memory in 1MB chunks instead of 10MB chunks.
2. Added progress printing every 50MB to monitor the memory allocation process.
3. Changed the way memory is released at the end of the simulation to use `del allocated_memory[:]` instead of `allocated_memory = []` for better memory management.

With these changes, the memory spike simulation should be able to allocate the desired amount of memory (700MB) without causing out-of-memory errors or excessive memory pressure on the pod.